### PR TITLE
Configure backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ A dbt profile can be configured to run against Presto using the following config
 | schema  | Specify the schema to build models into | Required | `dbt_drew` |
 | region_name | Specify in which AWS region it should connect | Required | `eu-west-1` |
 | threads    | How many threads dbt should use | Optional(default=`1`) | `8` |
+| max_retry_number | Number for retries for exponential backoff | Optional(default=`5`) | `8` |
+| max_retry_delay  | Maximum delay for exponential backoff in seconds | Optional(default=`100`) | `8` |
 
 
 **Example profiles.yml entry:**


### PR DESCRIPTION
- Athena has service quotas: https://docs.aws.amazon.com/athena/latest/ug/service-limits.html and 

Athena client handles it with exponential backoff: 

https://github.com/laughingman7743/PyAthena/blob/614a9b81ad0e3faaf9532c46abe61cac94557259/pyathena/util.py#L189

However default configuration may be not sufficient for concurrent DBT run, so this PR introduces a way to tune it based on needs and configured threads/quotas