### PR TITLE
Upgrade to dbt version 0.16.1

### DIFF
--- a/dbt/include/athena/macros/catalog.sql
+++ b/dbt/include/athena/macros/catalog.sql
@@ -1,8 +1,7 @@
 
-{% macro athena__get_catalog(information_schemas) -%}
+{% macro athena__get_catalog(information_schema, schemas) -%}
     {%- call statement('catalog', fetch_result=True) -%}
     select * from (
-    {% for information_schema in information_schemas %}
 
         (
             with tables as (
@@ -43,11 +42,14 @@
             from tables
             join columns using ("table_database", "table_schema", "table_name")
             where "columns"."table_schema" != 'information_schema'
+            and (
+            {%- for schema in schemas -%}
+              upper("table_schema") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
+            {%- endfor -%}
+            )
             order by "column_index"
         )
-        {% if not loop.last %} union all {% endif %}
 
-    {% endfor %}
     )
   {%- endcall -%}
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(this_directory, "README.md")) as f:
 
 
 package_name = "dbt-athena"
-package_version = "0.15.3"
+package_version = "0.16.1"
 description = """The athena adpter plugin for dbt (data build tool)"""
 
 setup(


### PR DESCRIPTION
Pull request for #28. 

I tried to upgrade to use dbt 0.16.1 and it worked without modifications. I saw that the macro get_catalog had changed so I updated that, it is almost identical to the same macro in the presto plugin. 

https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-0-16-0#get_catalog-macro-interface-change