### PR TITLE
fix `dbt docs generate` for athena execution engines 1 & 2.

### DIFF
--- a/dbt/adapters/athena/connections.py
+++ b/dbt/adapters/athena/connections.py
@@ -99,9 +99,9 @@ class CursorWrapper(object):
 class ConnectionWrapper(object):
     """Wrap a Athena connection in a way that accomplishes two tasks:
 
-        - prefetch results from execute() calls so that presto calls actually
-            persist to the db but then present the usual cursor interface
-        - provide `cancel()` on the same object as `commit()`/`rollback()`/...
+    - prefetch results from execute() calls so that presto calls actually
+        persist to the db but then present the usual cursor interface
+    - provide `cancel()` on the same object as `commit()`/`rollback()`/...
 
     """
 

--- a/dbt/include/athena/macros/catalog.sql
+++ b/dbt/include/athena/macros/catalog.sql
@@ -7,14 +7,17 @@
             with tables as (
 
                 select
-                    table_catalog as "table_database",
-                    table_schema as "table_schema",
-                    table_name as "table_name",
-                    table_type as "table_type",
+                    t.table_catalog as "table_database",
+                    t.table_schema as "table_schema",
+                    t.table_name as "table_name",
+                    case when v.table_name is not null then 'VIEW' ELSE t.table_type END as "table_type",
                     null as "table_owner"
 
-                from {{ information_schema }}.tables
-
+                from {{ information_schema }}.tables t
+                left join {{ information_schema }}.views v
+                       on t.table_catalog = v.table_catalog
+                      and t.table_schema = v.table_schema
+                      and t.table_name = v.table_name
             ),
 
             columns as (

--- a/dbt/include/athena/macros/catalog.sql
+++ b/dbt/include/athena/macros/catalog.sql
@@ -38,24 +38,24 @@
                  , t."table_schema"
                  , t."table_name"
                  , t."table_type"
-                 , t."table_owner"
                  , c."table_comment"
                  , c."column_name"
                  , c."column_index"
                  , c."column_type"
                  , c."column_comment"
+                 , t."table_owner"
             from tables t
             join columns c 
               on t."table_database" = c."table_database"
              and t."table_schema" = c."table_schema" 
-             and t."table_name" = t."table_name"
+             and t."table_name" = c."table_name"
             where t."table_schema" != 'information_schema'
             and (
             {%- for schema in schemas -%}
               upper(t."table_schema") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
             {%- endfor -%}
             )
-            order by "column_index"
+            order by t."table_database", t."table_schema", t."table_name", c."column_index"
         )
 
     )

--- a/dbt/include/athena/macros/catalog.sql
+++ b/dbt/include/athena/macros/catalog.sql
@@ -34,17 +34,25 @@
 
             )
 
-            select tables.*,
-                   columns.column_name,
-                   columns.column_index,
-                   columns.column_type,
-                   columns.column_comment
-            from tables
-            join columns using ("table_database", "table_schema", "table_name")
-            where "columns"."table_schema" != 'information_schema'
+            select t."table_database"
+                 , t."table_schema"
+                 , t."table_name"
+                 , t."table_type"
+                 , t."table_owner"
+                 , c."table_comment"
+                 , c."column_name"
+                 , c."column_index"
+                 , c."column_type"
+                 , c."column_comment"
+            from tables t
+            join columns c 
+              on t."table_database" = c."table_database"
+             and t."table_schema" = c."table_schema" 
+             and t."table_name" = t."table_name"
+            where t."table_schema" != 'information_schema'
             and (
             {%- for schema in schemas -%}
-              upper("table_schema") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
+              upper(t."table_schema") = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
             {%- endfor -%}
             )
             order by "column_index"


### PR DESCRIPTION
execution engine 2 is being rolled out in us-east-1 (and a few other regions) currently.
soon, it will become the default engine athena uses worldwide.

there are some sql-parsing incompatibilities between the two versions when tables are
joined like this

```
from table1
join table2 using (col1, col2)
```

in version 1, it was necessary to specify `col1` as either `table1.col1` or `table2.col1`
in the where clause or select clause. however in version 2, that generates an error

to ensure compatibility across both versions, the simplest thing to do is to avoid specifying
the join as `using (col1, col2)`

this pattern is currently used in fetching the database metadata when executing `dbt docs generate`, so
I was not able to build docs against athena running on execution engine version 2.

with the change, `dbt docs generate` works successfully across both engine versions.

## limitation with athena execution engine version 1

`information.colunms` does not seem to contain information about views. This seems to have been fixed in engine v2